### PR TITLE
refs #06 Change webforms' Note toggle from a checkbox to a button;

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -79,3 +79,10 @@ body {
   font-family: "Courier New";
 }
 
+.note-button {
+  margin: 10px 0px 10px 0px;
+}
+
+#note {
+  margin-bottom: 10px;
+}

--- a/app/views/shared/_note.html.erb
+++ b/app/views/shared/_note.html.erb
@@ -4,7 +4,7 @@
   });
 </script>
 <section>
-  <h3 style="display:inline;">Note</h3> <input type=checkbox name="note_toggle" onclick="$('#note').toggle()">
+  <button type="button" class="btn btn-info note-button" onclick="$('#note').toggle()">Note</button> 
   <div id="note">
     <%= f.hidden_field :commentable_id  %>
     <%= f.hidden_field :commentable_type %>


### PR DESCRIPTION
For issue #6, I removed the `<h3>` and `<input type="checkbox...` tags and added a bootstrap `<button>`. I added two CSS rules, one for the button and one for the text input, so the elements aren't stuck together on screen. 